### PR TITLE
Make use of the new 'reverse' and fromInstant/fromBuild query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ $ build/install/gradle-enterprise-api-samples/bin/gradle-enterprise-api-samples 
 - `«serverUrl»`: The address of your Gradle Enterprise server (e.g. `https://ge.example.com`)
 - `«accessKeyFile»`: The path to the file containing the access key
 - `«projectName»` (optional): The name of the project to limit reporting to (reports all builds when omitted)
+- `«reverse»` (optional): A boolean indicating the time direction of the query. A value of true indicates a backward query. A value of false indicates a forward query (default: false).
 - `«maxBuilds»` (optional): The maximum number of builds to return by a single query. The number may be lower if --max-wait-secs is reached (default - 100)
 - `«maxWaitSecs»` (optional): The maximum number of seconds to wait until a query returns. If the query returns before --max-builds is reached, it returns with already processed builds (default - 3)
 
-The program will print `Processing builds ...`, then indefinitely listen for any new builds being published to Gradle Enterprise and print basic information about each build to the console.
+The program will print `Processing builds ...`, then:
+- when not using `--reverse` or using `--reverse=false`: indefinitely listen for any new builds being published to Gradle Enterprise and print basic information about each build to the console.
+- when using `--reverse` or `--reverse=true`: listen for all builds that were already published to Gradle Enterprise and print basic information about each build to the console.
+
 To stop the program, use <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 ## The sample code

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpmime:4.5.13")
 }
 
-val gradleEnterpriseVersion = "2022.3" // Must be later than 2022.1
+val gradleEnterpriseVersion = "2022.3.5" // Must be later than 2022.1
 val baseApiUrl = providers.gradleProperty("apiManualUrl").orElse("https://docs.gradle.com/enterprise/api-manual/ref/")
 
 val apiSpecificationFileGradleProperty = providers.gradleProperty("apiSpecificationFile")


### PR DESCRIPTION
Update the sample project logic to allow searching for builds in reverse, and using the non-deprecated `fromInstant`/`fromBuild` query parameters.