### PR TITLE
Bump org.openapi.generator from 6.2.0 to 6.2.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ group = "com.gradle.enterprise.api"
 description = "Gradle Enterprise API sample"
 
 plugins {
-    id("org.openapi.generator") version "6.2.0"
+    id("org.openapi.generator") version "6.2.1"
     kotlin("jvm") version embeddedKotlinVersion apply false
     `java-library`
     application


### PR DESCRIPTION
Bumps org.openapi.generator from 6.2.0 to 6.2.1.

---
updated-dependencies:
- dependency-name: org.openapi.generator dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>