### PR TITLE
Add containerDefaultToNull to OpenAPI Generator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,8 @@ openApiGenerate {
         "useBeanValidation" to "false",
         "disallowAdditionalPropertiesIfNotPresent" to "false",
         "additionalModelTypeAnnotations" to  "@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)",
-        "sourceFolder" to ""  // makes IDEs like IntelliJ more reliably interpret the class packages.
+        "sourceFolder" to "",  // makes IDEs like IntelliJ more reliably interpret the class packages.
+        "containerDefaultToNull" to "true"
     ))
 }
 


### PR DESCRIPTION
Currently, if a list property is not present in the response, the client will deserialize it to an empty list. This change will ensure that the client does not assign any value to missing properties, and they will be `null` as expected.