### PR TITLE
Revert "Bump org.apache.httpcomponents.client5:httpclient5 from 5.2.1 to 5.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.16.0")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.2.2")
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.2.1")
 
     testImplementation("org.mock-server:mockserver-netty:5.15.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")


### PR DESCRIPTION
### Summary

This reverts commit 48fe9523eac4c3b53c51cb091206ca793d95b60a.

5.2.2 introduced this issue which we are impacted by: https://issues.apache.org/jira/browse/HTTPCLIENT-2308. If using 5.2.2, the sample fails with:

```
build/install/develocity-api-samples/bin/develocity-api-samples --server-url=https://e.grdev.net --access-key-file=./access_key_file.txt
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Processing builds ...
java.lang.IllegalArgumentException: Invalid Proxy
	at java.base/java.net.Socket.<init>(Socket.java:177)
	at org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory.createSocket(SSLConnectionSocketFactory.java:208)
	at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:158)
	at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:447)
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:162)
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:172)
	at org.apache.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:142)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:192)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec.execute(HttpRequestRetryExec.java:96)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ContentCompressionExec.execute(ContentCompressionExec.java:152)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.RedirectExec.execute(RedirectExec.java:115)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:170)
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:106)
	at com.gradle.enterprise.api.client.ApiClient.invokeAPI(ApiClient.java:968)
	at com.gradle.enterprise.api.GradleEnterpriseApi.getBuilds(GradleEnterpriseApi.java:904)
	at com.gradle.enterprise.api.GradleEnterpriseApi.getBuilds(GradleEnterpriseApi.java:852)
	at com.develocity.api.BuildsProcessor.process(BuildsProcessor.java:38)
	at com.develocity.api.SampleMain.call(SampleMain.java:103)
	at com.develocity.api.SampleMain.call(SampleMain.java:15)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at com.develocity.api.SampleMain.main(SampleMain.java:79)
```