### PR TITLE
Ignore mockserver 6+ in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,9 @@ updates:
         patterns: 
           - "com.fasterxml.jackson*"      
       slf4j:
-        patterns: 
+        patterns:
           - "org.slf4j*"
+    ignore:
+      # mockserver 6+ requires Java 11+, which this project does not target
+      - dependency-name: "org.mock-server:mockserver-netty"
+        versions: [">=6"]


### PR DESCRIPTION
## What

Adds a dependabot `ignore` directive for `org.mock-server:mockserver-netty` to skip version `6` and above.

## Why

mockserver 6.x requires Java 11+, which this project does not target. As a result, dependabot PRs bumping mockserver to 6.x cannot be merged (e.g. #230). This pins dependabot to the 5.x line so it stops opening unmergeable PRs, while still allowing 5.x updates.

Closes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)